### PR TITLE
add invoice endpoints for moneybird data

### DIFF
--- a/dev_config/subscription.yml
+++ b/dev_config/subscription.yml
@@ -5,5 +5,5 @@ diskspace: 500MB
 
 moneybird:
   # Eonics' contact_id
-  contact_id: 211786024202798994
+  contact_id: '211786024202798994'
   reference: Observ

--- a/dev_config/subscription.yml
+++ b/dev_config/subscription.yml
@@ -2,3 +2,8 @@ workers: 5
 build-slaves: 4
 users: 15
 diskspace: 500MB
+
+moneybird:
+  # Eonics' contact_id
+  contact_id: 211786024202798994
+  reference: Observ

--- a/moneybird.js
+++ b/moneybird.js
@@ -1,0 +1,23 @@
+const SuperAgent = require('superagent');
+
+const {MONEYBIRD_API_TOKEN, MONEYBIRD_ADMINISTRATION_ID} = process.env;
+
+exports.getContactData = async (contactId) => {
+    const contact_request = await SuperAgent
+        .get(`https://moneybird.com/api/v2/${MONEYBIRD_ADMINISTRATION_ID}/contacts/${contactId}`)
+        .set('Authorization', `Bearer ${MONEYBIRD_API_TOKEN}`)
+        .set('Accept', 'application/json')
+    return contact_request.body
+}
+
+exports.getInvoices = async (contactId, reference = null) => {
+
+    const url = `https://moneybird.com/api/v2/${MONEYBIRD_ADMINISTRATION_ID}/sales_invoices?filter=contact_id:${contactId}`
+    console.log(url)
+    const invoices_request = await SuperAgent
+        .get(`https://moneybird.com/api/v2/${MONEYBIRD_ADMINISTRATION_ID}/sales_invoices?filter=contact_id:${contactId}`)
+        .set('Authorization', `Bearer ${MONEYBIRD_API_TOKEN}`)
+        .set('Accept', 'application/json')
+
+    return invoices_request.body.filter( invoice => invoice.reference == reference )
+}

--- a/moneybird.js
+++ b/moneybird.js
@@ -1,8 +1,8 @@
 const SuperAgent = require('superagent');
-
 const {MONEYBIRD_API_TOKEN, MONEYBIRD_ADMINISTRATION_ID} = process.env;
 
 exports.getContactData = async (contactId) => {
+
     const contact_request = await SuperAgent
         .get(`https://moneybird.com/api/v2/${MONEYBIRD_ADMINISTRATION_ID}/contacts/${contactId}`)
         .set('Authorization', `Bearer ${MONEYBIRD_API_TOKEN}`)
@@ -12,8 +12,6 @@ exports.getContactData = async (contactId) => {
 
 exports.getInvoices = async (contactId, reference = null) => {
 
-    const url = `https://moneybird.com/api/v2/${MONEYBIRD_ADMINISTRATION_ID}/sales_invoices?filter=contact_id:${contactId}`
-    console.log(url)
     const invoices_request = await SuperAgent
         .get(`https://moneybird.com/api/v2/${MONEYBIRD_ADMINISTRATION_ID}/sales_invoices?filter=contact_id:${contactId}`)
         .set('Authorization', `Bearer ${MONEYBIRD_API_TOKEN}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,11 @@
       "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -396,6 +401,14 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -441,6 +454,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -582,6 +600,11 @@
           }
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -952,6 +975,21 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1017,14 +1055,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1039,20 +1075,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1169,8 +1202,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1182,7 +1214,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1197,7 +1228,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1205,14 +1235,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1231,7 +1259,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1312,8 +1339,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1325,7 +1351,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1447,7 +1472,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2834,7 +2858,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -2850,6 +2873,63 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.0.5.tgz",
+      "integrity": "sha512-5fnihpNqJfDJHxeIkqlXKFDOW5t4WUFV8Ba1erxdWT0RySqjgAW6Hska0xNYEpAfaoMzubn77GROm/XlkssOoQ==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "form-data": "^2.3.3",
+        "formidable": "^1.2.1",
+        "methods": "^1.1.2",
+        "mime": "^2.4.2",
+        "qs": "^6.7.0",
+        "readable-stream": "^3.3.0",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+        }
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -3112,8 +3192,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "js-yaml": "^3.13.0",
     "jsonwebtoken": "^8.5.0",
     "node-fetch": "^2.3.0",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "superagent": "^5.0.5"
   },
   "devDependencies": {
     "nodemon": "^1.18.10"

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const yaml = require('js-yaml');
 const Fetch = require('./fetch.js');
 const DevFetch = require('./devFetch.js');
+const {getInvoices, getContactData} = require('./moneybird');
 
 const {ENV} = process.env;
 
@@ -129,6 +130,24 @@ server.get('/api/workers', function (req, res) {
             onRejected(error)
         });
 
+});
+
+server.get('/api/invoices', async function (req, res) {
+    const {moneybird} = yaml.load(await fetch.fetchFromFile(req, 'subscription.yml'))
+
+    console.log('Fetching invoice data from moneybird: ', moneybird)
+    const invoices = await getInvoices(moneybird.contact_id, moneybird.reference);
+
+    res.status(200).send(invoices);
+});
+
+server.get('/api/invoice_contact', async function (req, res) {
+
+    const {moneybird} = yaml.load(await fetch.fetchFromFile(req, 'subscription.yml'))
+    console.log('Fetching contact data from moneybird')
+    const contact_data = await getContactData(moneybird.contact_id);
+
+    res.status(200).send(contact_data);
 });
 
 server.post('/api/workers', function (req, res) {

--- a/server.js
+++ b/server.js
@@ -134,6 +134,18 @@ server.get('/api/workers', function (req, res) {
 
 });
 
+server.get('/api/can_view_invoices', async function (req, res) {
+
+    try {
+        const {moneybird} = await loadSubscriptionFile(req)
+        if (moneybird.contact_id && moneybird.reference) {
+            res.status(200).send({message: true});
+        }
+    } catch (err) {
+        res.status(200).send({message: false});
+    }
+});
+
 server.get('/api/invoices', async function (req, res) {
     const {moneybird} = await loadSubscriptionFile(req)
 

--- a/server.js
+++ b/server.js
@@ -23,6 +23,8 @@ switch (ENV) {
         break;
 }
 
+const loadSubscriptionFile = async (req) =>
+    yaml.load(await fetch.fetchFromFile(req, 'subscription.yml'))
 
 server.get('/api/config', function (req, res) {
     let result = {};
@@ -133,21 +135,27 @@ server.get('/api/workers', function (req, res) {
 });
 
 server.get('/api/invoices', async function (req, res) {
-    const {moneybird} = yaml.load(await fetch.fetchFromFile(req, 'subscription.yml'))
+    const {moneybird} = await loadSubscriptionFile(req)
 
-    console.log('Fetching invoice data from moneybird: ', moneybird)
-    const invoices = await getInvoices(moneybird.contact_id, moneybird.reference);
-
-    res.status(200).send(invoices);
+    console.log('Fetching invoice data from moneybird')
+    try {
+        const invoices = await getInvoices(moneybird.contact_id, moneybird.reference);
+        res.status(200).send(invoices);
+    } catch (err) {
+        res.status(500).send({message: "Error fetching invoices, is the configuration available?"});
+    }
 });
 
 server.get('/api/invoice_contact', async function (req, res) {
 
-    const {moneybird} = yaml.load(await fetch.fetchFromFile(req, 'subscription.yml'))
+    const {moneybird} = await loadSubscriptionFile(req)
     console.log('Fetching contact data from moneybird')
-    const contact_data = await getContactData(moneybird.contact_id);
-
-    res.status(200).send(contact_data);
+    try {
+        const contact_data = await getContactData(moneybird.contact_id);
+        res.status(200).send(contact_data);
+    } catch (err) {
+        res.status(500).send({message: "Error fetching invoice contact, is the configuration available?"});
+    }
 });
 
 server.post('/api/workers', function (req, res) {


### PR DESCRIPTION
This adds the following endpoints:
- `/api/invoices` Retrieves invoices from moneybird and returns them
- `/api/invoice_contact` Retrieves contact data for a company we do business with.
- `/api/can_view_invoices` Checks if moneybird credentials are available and returns true or false

Please keep the following in mind:
It expects `MONEYBIRD_API_TOKEN` and `MONEYBIRD_ADMINISTRATION_ID` in the environment.
It expects a moneybird.contact_id, and moneybird.reference in the subsciption.yml.
The contact_id is to only retrieve invoices for this company, and which contact to retrieve data for.
The reference is to filter invoices per project.